### PR TITLE
Fix_and_consistency

### DIFF
--- a/R/joyn-merge.R
+++ b/R/joyn-merge.R
@@ -515,8 +515,7 @@ joyn <- function(x,
 
   }
 
-
-
-  return(x)
+  setattr(x, "class", class_x)
+  x
 
 }

--- a/R/joyn-merge.R
+++ b/R/joyn-merge.R
@@ -364,14 +364,18 @@ joyn <- function(x,
   ## rows to keep -----
   if (keep  %in% c("master", "left") ) {
 
-    x <- x[get(reportvar)  != 2]
+    x <- x |>
+      fsubset(get(reportvar)  != 2)
 
   } else if (keep  %in% c("using", "right") ) {
 
-    x <- x[get(reportvar)  != 1]
+    x <- x |>
+      fsubset(get(reportvar)  != 1)
 
   } else if (keep  == "inner") {
-    x <- x[get(reportvar)  >= 3]
+
+    x <- x |>
+      fsubset(get(reportvar)  >= 3)
   }
 
 

--- a/R/update_NAs.R
+++ b/R/update_NAs.R
@@ -76,27 +76,16 @@ update_NAs <- function(dt, var, reportvar = ".joyn", suffix = NULL) {
 
 
   # remove unnecessary columns
-  dt <- dt[
-    ,
-    mget(
-      names(dt)[
-        which(
-          !names(dt) %in% c("varx_na", "vary_na")
-        )
-      ]
-    )
-  ]
+
+  vars_to_keep <- names(dt)[names(dt) %!in% c("varx_na", "vary_na")]
+  dt <- get_vars(dt, vars_to_keep)
+
 
   # adjust reportvar
-  dt |> fselect(reportvar) <- NULL
-  names(dt)[
-    which(
-      names(dt) == "use_util_reportvar"
-    )
-  ] <- reportvar
+  get_vars(dt, reportvar) <- NULL
+  setrename(dt, use_util_reportvar = reportvar, .nse = FALSE)
 
-  return(dt)
-
+  dt
 }
 
 

--- a/R/update_NAs.R
+++ b/R/update_NAs.R
@@ -11,7 +11,9 @@ if (getRversion() >= '2.15.1')
 #'
 #' @return data.table
 #' @noRd
-update_NAs <- function(dt, var, reportvar = ".joyn", suffix = NULL) {
+update_NAs <- function(dt, var,
+                       reportvar = getOption("joyn.reportvar"),
+                       suffix = NULL) {
 
   if (is.null(suffix)) {
     suffix <- c("", ".y")

--- a/R/update_NAs.R
+++ b/R/update_NAs.R
@@ -12,7 +12,7 @@ if (getRversion() >= '2.15.1')
 #' @return data.table
 #' @noRd
 update_NAs <- function(dt, var,
-                       reportvar = getOption("joyn.reportvar"),
+                       reportvar,
                        suffix = NULL) {
 
   if (is.null(suffix)) {
@@ -21,64 +21,27 @@ update_NAs <- function(dt, var,
   x.var <- paste0(var, suffix[1])
   y.var <- paste0(var, suffix[2])
 
-  dt$use_util_reportvar <- dt |>
-    fselect(get(reportvar))
-
-  # create variable for var.x is NA
-  dt$varx_na <- dt |>
-    fselect(x.var) |>
-    {\(.) !missing_cases(.)}() # TRUE if not NA
-
-
-  # create variable for var.y is NA
-  dt$vary_na <- dt |>
-    fselect(y.var) |>
-    {\(.) !missing_cases(.)}() # TRUE if not NA
-
-  # let report reflect updates
-  dt[
-    !dt$varx_na & !(dt$use_util_reportvar %in% c(4)),  # FALSE => is NA and not 2, 4 => NA updated
-    c("use_util_reportvar")
-  ] <- 4L
+  dt <- dt |>
+    ftransform(use_util_reportvar = get(reportvar),
+               # create variable for var.x is NA
+               # TRUE if not NA
+               varx_na            = !missing_cases(get(x.var)),
+               vary_na            = !missing_cases(get(y.var)))
 
 
+  # let `use_util_reportvar` reflect updates
+  dt$use_util_reportvar[
+    !dt$varx_na & !(dt$use_util_reportvar %in% 4)] <- 4L
+
+  # Replace values
   # Now update the vars if 4
-  if (!"data.table" %in% class(dt)) {
+  to_replace <- which(dt$use_util_reportvar == 4 |
+                        # Update x vars if NA by report is 2 (i.e. row only in y)
+                        (dt$use_util_reportvar == 2 & dt$varx_na == FALSE))
 
-    dt[
-      which(dt$use_util_reportvar %in% c(4)),
-      x.var
-    ] <- lapply(
-      y.var,
-      function(y) dt[
-        dt$use_util_reportvar %in% c(4),
-        y
-      ]
-    )
-    # Update x vars if NA by report is 2 (i.e. row only in y)
-    dt[
-      which(dt$use_util_reportvar %in% c(2) & dt$varx_na == FALSE),
-      x.var
-    ]  <- lapply(
-      y.var,
-      function(y) dt[
-        which(dt$use_util_reportvar %in% c(2) & dt$varx_na == FALSE),
-        y
-      ]
-    )
-
-  } else{
-    dt[
-      use_util_reportvar %in% c(4),
-      (x.var) := get(y.var)
-    ]
-  }
-
-  # Update x vars if NA by report is 2 (i.e. row only in y)
-
+  dt[[x.var]][to_replace] <- dt[[y.var]][to_replace]
 
   # remove unnecessary columns
-
   vars_to_keep <- names(dt)[names(dt) %!in% c("varx_na", "vary_na")]
   dt <- get_vars(dt, vars_to_keep)
 

--- a/R/update_values.R
+++ b/R/update_values.R
@@ -44,7 +44,7 @@ update_values <- function(dt, var,
   # Replace values
   to_replace <- which(dt$use_util_reportvar %in% c(4, 5))
 
-  x[[x.var]][to_replace] <- dt[[y.var]][to_replace]
+  dt[[x.var]][to_replace] <- dt[[y.var]][to_replace]
 
 
   # remove unnecessary columns

--- a/R/update_values.R
+++ b/R/update_values.R
@@ -12,7 +12,8 @@ if (getRversion() >= '2.15.1')
 #'
 #' @return data.table
 #' @noRd
-update_values <- function(dt, var, reportvar = ".joyn", suffix = NULL) {
+update_values <- function(dt, var,
+                          reportvar = ".joyn", suffix = NULL) {
 
   if (is.null(suffix)) {
     suffix <- c("", ".y")
@@ -69,24 +70,13 @@ update_values <- function(dt, var, reportvar = ".joyn", suffix = NULL) {
 
 
   # remove unnecessary columns
-  dt <- dt[
-    ,
-    mget(
-      names(dt)[
-        which(
-          !names(dt) %in% c("varx_na", "vary_na")
-        )
-      ]
-    )
-  ]
+  vars_to_keep <- names(dt)[names(dt) %!in% c("varx_na", "vary_na")]
+  dt <- get_vars(dt, vars_to_keep)
+
 
   # adjust reportvar
-  dt |> fselect(reportvar) <- NULL
-  names(dt)[
-    which(
-      names(dt) == "use_util_reportvar"
-    )
-  ] <- reportvar
+  get_vars(dt, reportvar) <- NULL
+  setrename(dt, use_util_reportvar = reportvar, .nse = FALSE)
 
   return(dt)
 }

--- a/R/update_values.R
+++ b/R/update_values.R
@@ -13,7 +13,8 @@ if (getRversion() >= '2.15.1')
 #' @return data.table
 #' @noRd
 update_values <- function(dt, var,
-                          reportvar = ".joyn", suffix = NULL) {
+                          reportvar = getOption("joyn.reportvar"),
+                          suffix = NULL) {
 
   if (is.null(suffix)) {
     suffix <- c("", ".y")

--- a/tests/testthat/test-dplyr-joins.R
+++ b/tests/testthat/test-dplyr-joins.R
@@ -389,7 +389,8 @@ test_that("RIGHT JOIN - Conducts right join", {
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
     jn |> fselect(-get(reportvar)),
-    jn_dplyr
+    jn_dplyr,
+    ignore_attr = '.internal.selfref'
   )
 
 })
@@ -651,7 +652,8 @@ test_that("FULL JOIN - Conducts full join", {
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
     jn |> fselect(-get(reportvar)),
-    jn_dplyr
+    jn_dplyr,
+    ignore_attr = '.internal.selfref'
   )
 
 })
@@ -729,8 +731,14 @@ test_that("FULL JOIN - argument `keep` preserves keys in output", {
     "id.y" %in% names(jn)
   )
   expect_equal(
-    jn[, id.y] |> na.omit() |> unique(),
-    y1$id |> unique()
+    jn |>
+      fselect(id.y) |>
+      na.omit() |>
+      unique() |>
+      reg_elem(),
+
+    y1$id |>
+      unique()
   )
 
 })
@@ -899,7 +907,8 @@ test_that("INNER JOIN - Conducts inner join", {
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
     jn |> fselect(-get(reportvar)),
-    jn_dplyr
+    jn_dplyr,
+    ignore_attr = '.internal.selfref'
   )
 
 })

--- a/tests/testthat/test-dplyr-joins.R
+++ b/tests/testthat/test-dplyr-joins.R
@@ -251,17 +251,22 @@ test_that("LEFT JOIN - update values works", {
     by = "id"
   )
 
-  # vupdated <- jn |>
-  #   fsubset(get(reportvar) == "value updated") |>
-  #   fselect(x.x) |>
-  #   reg_elem()
+  vupdated <- jn |>
+    fsubset(get(reportvar) == "value updated") |>
+    fselect(x.x) |>
+    reg_elem()
 
   expect_true(
-    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
+    all(vupdated %in% y2$x)
   )
+
   expect_equal(
-    nrow(jn[get(reportvar) == "value updated",]),
-    nrow(x2[id %in% y2$id])
+    jn |>
+      fsubset(get(reportvar) == "value updated") |>
+      fnrow(),
+    x2 |>
+      fsubset(id %in% y2$id) |>
+      fnrow()
   )
 
 
@@ -293,7 +298,9 @@ test_that("LEFT JOIN - NA matches", {
   )
 
   expect_equal(
-    jn[is.na(id), ] |> nrow(),
+    jn |>
+      fsubset(is.na(id)) |>
+      nrow(),
     4
   )
 
@@ -301,16 +308,7 @@ test_that("LEFT JOIN - NA matches", {
 })
 
 
-
-
-
-
-
-#-------------------------------------------------------------------------------
-# TEST RIGHT JOINS -------------------------------------------------------------
-#-------------------------------------------------------------------------------
-
-
+# TEST RIGHT JOINS ------------------------------------------------------
 
 test_that("RIGHT JOIN - Conducts right join", {
 
@@ -330,7 +328,8 @@ test_that("RIGHT JOIN - Conducts right join", {
   )
 
   jn_dplyr <- dplyr::right_join(
-    x1, y1, by = "id", relationship = "many-to-one"
+    x1, y1, by = "id",
+    relationship = "many-to-one"
   )
   attr(
     jn_dplyr,
@@ -468,8 +467,16 @@ test_that("RIGHT JOIN - argument `keep` preserves keys in output", {
     "id.x" %in% names(jn)
   )
   expect_equal(
-    jn[, id.x] |> na.omit() |> unique(),
-    x1[id %in% y1$id]$id |> unique()
+    jn |>
+      fselect(id.x) |>
+      na.omit() |>
+      unique() |>
+      reg_elem(),
+    x1 |>
+      fsubset(id %in% y1$id) |>
+      fselect(id) |>
+      unique() |>
+      reg_elem()
   )
 
 })
@@ -489,15 +496,24 @@ test_that("RIGHT JOIN - update values works", {
     by = "id"
   )
 
+
+  vupdated <- jn |>
+    fsubset(get(reportvar) == "value updated") |>
+    fselect(x.x) |>
+    reg_elem()
+
   expect_true(
-    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
+    all(vupdated %in% y2$x)
   )
+
   expect_equal(
-    nrow(jn[get(reportvar) == "value updated",]),
-    nrow(x2[id %in% y2$id])
+    jn |>
+      fsubset(get(reportvar) == "value updated") |>
+      fnrow(),
+    x2 |>
+      fsubset(id %in% y2$id) |>
+      fnrow()
   )
-
-
 
 })
 
@@ -527,10 +543,11 @@ test_that("RIGHT JOIN - NA matches", {
   )
 
   expect_equal(
-    jn[is.na(id), ] |> nrow(),
+    jn |>
+      fsubset(is.na(id)) |>
+      nrow(),
     4
   )
-
 
 })
 
@@ -733,15 +750,23 @@ test_that("FULL JOIN - update values works", {
     by = "id"
   )
 
+  vupdated <- jn |>
+    fsubset(get(reportvar) == "value updated") |>
+    fselect(x.x) |>
+    reg_elem()
+
   expect_true(
-    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
+    all(vupdated %in% y2$x)
   )
+
   expect_equal(
-    nrow(jn[get(reportvar) == "value updated",]),
-    nrow(x2[id %in% y2$id])
+    jn |>
+      fsubset(get(reportvar) == "value updated") |>
+      fnrow(),
+    x2 |>
+      fsubset(id %in% y2$id) |>
+      fnrow()
   )
-
-
 
 })
 
@@ -763,7 +788,6 @@ test_that("FULL JOIN - reportvar works", {
 
 test_that("FULL JOIN - NA matches", {
 
-
   jn <- full_join(
     x5,
     y5,
@@ -771,10 +795,11 @@ test_that("FULL JOIN - NA matches", {
   )
 
   expect_equal(
-    jn[is.na(id), ] |> nrow(),
+    jn |>
+      fsubset(is.na(id)) |>
+      fnrow(),
     4
   )
-
 
 })
 
@@ -943,8 +968,16 @@ test_that("INNER JOIN - argument `keep` preserves keys in output", {
     "id.y" %in% names(jn)
   )
   expect_equal(
-    jn[, id.y] |> na.omit() |> unique(),
-    y1[id %in% x1$id]$id    |> unique()
+    jn |>
+      fselect(id.y) |>
+      na.omit() |>
+      unique() |>
+      reg_elem(),
+    y1 |>
+      fsubset(id %in% x1$id) |>
+      fselect(id) |>
+      unique() |>
+      reg_elem()
   )
 
 })
@@ -964,12 +997,22 @@ test_that("INNER JOIN - update values works", {
     by = "id"
   )
 
+  vupdated <- jn |>
+    fsubset(get(reportvar) == "value updated") |>
+    fselect(x.x) |>
+    reg_elem()
+
   expect_true(
-    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
+    all(vupdated %in% y2$x)
   )
+
   expect_equal(
-    nrow(jn[get(reportvar) == "value updated",]),
-    nrow(x2[id %in% y2$id])
+    jn |>
+      fsubset(get(reportvar) == "value updated") |>
+      fnrow(),
+    x2 |>
+      fsubset(id %in% y2$id) |>
+      fnrow()
   )
 
 
@@ -1002,10 +1045,11 @@ test_that("INNER JOIN - NA matches", {
   )
 
   expect_equal(
-    jn[is.na(id), ] |> nrow(),
+    jn |>
+      fsubset(is.na(id)) |>
+      fnrow(),
     4
   )
-
 
 })
 

--- a/tests/testthat/test-dplyr-joins.R
+++ b/tests/testthat/test-dplyr-joins.R
@@ -9,49 +9,50 @@ library(data.table) |>
 #-------------------------------------------------------------------------------
 
 # options(joyn.verbose = FALSE)
-x1 = data.table(id = c(1L, 1L, 2L, 3L, NA_integer_),
+x1 = data.frame(id = c(1L, 1L, 2L, 3L, NA_integer_),
                 t  = c(1L, 2L, 1L, 2L, NA_integer_),
                 x  = 11:15)
 
-y1 = data.table(id = c(1,2, 4),
+y1 = data.frame(id = c(1,2, 4),
                 y  = c(11L, 15L, 16))
 
 
-x2 = data.table(id = c(1, 4, 2, 3, NA),
+x2 = data.frame(id = c(1, 4, 2, 3, NA),
                 t  = c(1L, 2L, 1L, 2L, NA_integer_),
                 x  = c(16, 12, NA, NA, 15))
 
 
-y2 = data.table(id = c(1, 2, 5, 6, 3),
+y2 = data.frame(id = c(1, 2, 5, 6, 3),
                 yd = c(1, 2, 5, 6, 3),
                 y  = c(11L, 15L, 20L, 13L, 10L),
                 x  = c(16:20))
 
 
-y3 <- data.table(id = c("c","b", "c", "a"),
+y3 <- data.frame(id = c("c","b", "c", "a"),
                  y  = c(11L, 15L, 18L, 20L))
 
-x3 <- data.table(id  = c("c","b", "d"),
+x3 <- data.frame(id  = c("c","b", "d"),
                  v   = 8:10,
                  foo = c(4,2, 7))
 
-x4 = data.table(id1 = c(1, 1, 2, 3, 3),
+x4 = data.frame(id1 = c(1, 1, 2, 3, 3),
                 id2 = c(1, 1, 2, 3, 4),
                 t   = c(1L, 2L, 1L, 2L, NA_integer_),
                 x   = c(16, 12, NA, NA, 15))
 
 
-y4 = data.table(id  = c(1, 2, 5, 6, 3),
+y4 = data.frame(id  = c(1, 2, 5, 6, 3),
                 id2 = c(1, 1, 2, 3, 4),
                 y   = c(11L, 15L, 20L, 13L, 10L),
                 x   = c(16:20))
-x5 = data.table(id = c(1L, 1L, 2L, 3L, NA_integer_, NA_integer_),
+x5 = data.frame(id = c(1L, 1L, 2L, 3L, NA_integer_, NA_integer_),
                 t  = c(1L, 2L, 1L, 2L, NA_integer_, 4L),
                 x  = 11:16)
 
-y5 = data.table(id = c(1,2, 4, NA_integer_, NA_integer_),
+y5 = data.frame(id = c(1,2, 4, NA_integer_, NA_integer_),
                 y  = c(11L, 15L, 16, 17L, 18L))
 
+reportvar = getOption("joyn.reportvar")
 
 #-------------------------------------------------------------------------------
 # TEST LEFT JOINS --------------------------------------------------------------
@@ -76,7 +77,7 @@ test_that("LEFT JOIN - Conducts left join", {
     unmatched = "drop"
   )
 
-  jn_dplyr <- data.table(id = c(1, 1, 2, 3, NA),
+  jn_dplyr <- data.frame(id = c(1, 1, 2, 3, NA),
                          t = c(1, 2, 1, 2, NA),
                          x = c(11, 12, 13, 14, 15),
                          y = c(11, 11, 15, NA, NA))
@@ -86,8 +87,9 @@ test_that("LEFT JOIN - Conducts left join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
-    jn_dplyr
+    jn_joyn |> fselect(-get(reportvar)),
+    jn_dplyr,
+    ignore_attr = "row.names" # data.table::serorderv convert row.names to characters...
   )
   expect_equal(
     jn_joyn,
@@ -103,7 +105,7 @@ test_that("LEFT JOIN - Conducts left join", {
     by = "id"
   )
 
-  jn_dplyr <- data.table(id  = c(1, 4, 2, 3, NA),
+  jn_dplyr <- data.frame(id  = c(1, 4, 2, 3, NA),
                          t   = c(1, 2, 1, 2, NA),
                          x.x = c(16, 12, NA, NA, 15),
                          yd  = c(1, NA, 2, 3, NA),
@@ -116,8 +118,10 @@ test_that("LEFT JOIN - Conducts left join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
-    jn_dplyr
+    jn_joyn |>
+      fselect(-get(reportvar)), # `jvar` should be `.joyn` in principle
+    jn_dplyr,
+    ignore_attr = TRUE
   )
 
 
@@ -129,7 +133,7 @@ test_that("LEFT JOIN - Conducts left join", {
   )
 
   #dplyr::left_join(x4, y4, by = dplyr::join_by(id1 == id2), relationship = "many-to-many")
-  jn_dplyr <- data.table(id1 = c(1, 1, 1, 1, 2, 3, 3),
+  jn_dplyr <- data.frame(id1 = c(1, 1, 1, 1, 2, 3, 3),
                          id2 = c(1, 1, 1, 1, 2, 3, 4),
                          t   = c(1, 1, 2, 2, 1, 2, NA),
                          x.x = c(16, 16, 12, 12, NA, NA, 15),
@@ -138,7 +142,7 @@ test_that("LEFT JOIN - Conducts left join", {
                          x.y = c(16, 17, 16, 17, 18, 19, 19))
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
-    jn |> fselect(-`.joyn`),
+    jn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -239,10 +243,10 @@ test_that("LEFT JOIN - update values works", {
   )
 
   expect_true(
-    all(jn[`.joyn` == "value updated",]$x.x %in% y2$x)
+    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
   )
   expect_equal(
-    nrow(jn[`.joyn` == "value updated",]),
+    nrow(jn[get(reportvar) == "value updated",]),
     nrow(x2[id %in% y2$id])
   )
 
@@ -320,7 +324,7 @@ test_that("RIGHT JOIN - Conducts right join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
+    jn_joyn |> fselect(-get(reportvar)),
     jn_dplyr
   )
   expect_equal(
@@ -350,7 +354,7 @@ test_that("RIGHT JOIN - Conducts right join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
+    jn_joyn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -371,7 +375,7 @@ test_that("RIGHT JOIN - Conducts right join", {
   )
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
-    jn |> fselect(-`.joyn`),
+    jn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -472,10 +476,10 @@ test_that("RIGHT JOIN - update values works", {
   )
 
   expect_true(
-    all(jn[`.joyn` == "value updated",]$x.x %in% y2$x)
+    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
   )
   expect_equal(
-    nrow(jn[`.joyn` == "value updated",]),
+    nrow(jn[get(reportvar) == "value updated",]),
     nrow(x2[id %in% y2$id])
   )
 
@@ -556,7 +560,7 @@ test_that("FULL JOIN - Conducts full join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
+    jn_joyn |> fselect(-get(reportvar)),
     jn_dplyr
   )
   expect_equal(
@@ -593,7 +597,7 @@ test_that("FULL JOIN - Conducts full join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
+    jn_joyn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -614,7 +618,7 @@ test_that("FULL JOIN - Conducts full join", {
   )
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
-    jn |> fselect(-`.joyn`),
+    jn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -715,10 +719,10 @@ test_that("FULL JOIN - update values works", {
   )
 
   expect_true(
-    all(jn[`.joyn` == "value updated",]$x.x %in% y2$x)
+    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
   )
   expect_equal(
-    nrow(jn[`.joyn` == "value updated",]),
+    nrow(jn[get(reportvar) == "value updated",]),
     nrow(x2[id %in% y2$id])
   )
 
@@ -796,7 +800,7 @@ test_that("INNER JOIN - Conducts inner join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
+    jn_joyn |> fselect(-get(reportvar)),
     jn_dplyr
   )
   expect_equal(
@@ -833,7 +837,7 @@ test_that("INNER JOIN - Conducts inner join", {
   ) <- "id"
 
   expect_equal(
-    jn_joyn |> fselect(-`.joyn`),
+    jn_joyn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -854,7 +858,7 @@ test_that("INNER JOIN - Conducts inner join", {
   )
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
-    jn |> fselect(-`.joyn`),
+    jn |> fselect(-get(reportvar)),
     jn_dplyr
   )
 
@@ -946,10 +950,10 @@ test_that("INNER JOIN - update values works", {
   )
 
   expect_true(
-    all(jn[`.joyn` == "value updated",]$x.x %in% y2$x)
+    all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
   )
   expect_equal(
-    nrow(jn[`.joyn` == "value updated",]),
+    nrow(jn[get(reportvar) == "value updated",]),
     nrow(x2[id %in% y2$id])
   )
 

--- a/tests/testthat/test-dplyr-joins.R
+++ b/tests/testthat/test-dplyr-joins.R
@@ -251,6 +251,11 @@ test_that("LEFT JOIN - update values works", {
     by = "id"
   )
 
+  # vupdated <- jn |>
+  #   fsubset(get(reportvar) == "value updated") |>
+  #   fselect(x.x) |>
+  #   reg_elem()
+
   expect_true(
     all(jn[get(reportvar) == "value updated",]$x.x %in% y2$x)
   )

--- a/tests/testthat/test-dplyr-joins.R
+++ b/tests/testthat/test-dplyr-joins.R
@@ -121,7 +121,7 @@ test_that("LEFT JOIN - Conducts left join", {
     jn_joyn |>
       fselect(-get(reportvar)), # `jvar` should be `.joyn` in principle
     jn_dplyr,
-    ignore_attr = TRUE
+    ignore_attr = "row.names"
   )
 
 
@@ -132,18 +132,20 @@ test_that("LEFT JOIN - Conducts left join", {
     relationship = "many-to-many"
   )
 
-  #dplyr::left_join(x4, y4, by = dplyr::join_by(id1 == id2), relationship = "many-to-many")
-  jn_dplyr <- data.frame(id1 = c(1, 1, 1, 1, 2, 3, 3),
-                         id2 = c(1, 1, 1, 1, 2, 3, 4),
-                         t   = c(1, 1, 2, 2, 1, 2, NA),
-                         x.x = c(16, 16, 12, 12, NA, NA, 15),
-                         id  = c(1, 2, 1, 2, 5, 6, 6),
-                         y   = c(11, 15, 11, 15, 20, 13, 13),
-                         x.y = c(16, 17, 16, 17, 18, 19, 19))
+  jn_dplyr <- dplyr::left_join(x4, y4, by = dplyr::join_by(id1 == id2), relationship = "many-to-many")
+  # jn_dplyr <- data.frame(id1 = c(1, 1, 1, 1, 2, 3, 3),
+  #                        id2 = c(1, 1, 1, 1, 2, 3, 4),
+  #                        t   = c(1, 1, 2, 2, 1, 2, NA),
+  #                        x.x = c(16, 16, 12, 12, NA, NA, 15),
+  #                        id  = c(1, 2, 1, 2, 5, 6, 6),
+  #                        y   = c(11, 15, 11, 15, 20, 13, 13),
+  #                        x.y = c(16, 17, 16, 17, 18, 19, 19))
+
   attr(jn_dplyr, "sorted") <- "id1"
   expect_equal(
     jn |> fselect(-get(reportvar)),
-    jn_dplyr
+    jn_dplyr,
+    ignore_attr = ".internal.selfref"
   )
 
 })
@@ -221,8 +223,15 @@ test_that("LEFT JOIN - argument `keep` preserves keys in output", {
     "id.y" %in% names(jn)
   )
   expect_equal(
-    jn[, id.y] |> na.omit() |> unique(),
-    y1[id %in% x1$id]$id
+    jn |>
+      fselect(id.y) |>
+      na.omit() |>
+      unique() |>
+      reg_elem(),
+    y1 |>
+      fsubset(id %in% x1$id) |>
+      fselect(id) |>
+      reg_elem()
   )
 
 })
@@ -598,7 +607,8 @@ test_that("FULL JOIN - Conducts full join", {
 
   expect_equal(
     jn_joyn |> fselect(-get(reportvar)),
-    jn_dplyr
+    jn_dplyr,
+    ignore_attr = 'row.names'
   )
 
 


### PR DESCRIPTION
This version makes sure that all the dplyr tests pass using data.frame instead of data.table. 

In addition, several updates have been made to update_values and update_NAs. Now, they only depend on  base R and collapse. 

Note: we sill need to find a way to Replace values for rows matching a condition using {collapse} package 