### PR TITLE
Row order fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: joyn
 Type: Package
 Title: Tool for Diagnosis of Tables Joins and Complementary Join Features
-Version: 0.1.6.9001
+Version: 0.1.6.9002
 Authors@R: c(person(given = "R.Andres", 
                     family = "Castaneda", 
                     email = "acastanedaa@worldbank.org",

--- a/R/joyn-merge.R
+++ b/R/joyn-merge.R
@@ -212,12 +212,8 @@ joyn <- function(x,
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   start_joyn <- Sys.time()
   # copy objects if data.tables
-  if (any(class(x) == "data.table")) {
-    x <- copy(x)
-  }
-  if (any(class(y) == "data.table")) {
-    y <- copy(y)
-  }
+  x <- copy(x)
+  y <- copy(y)
 
   ## X and Y -----------
   check_xy(x,y)

--- a/R/joyn-merge.R
+++ b/R/joyn-merge.R
@@ -234,7 +234,6 @@ joyn <- function(x,
     y <- as.data.table(y)
   }
 
-
   ## Modify BY when is expression ---------
   fixby  <- check_by_vars(by, x, y)
   by     <- fixby$by
@@ -388,19 +387,6 @@ joyn <- function(x,
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   #                   Update x   ---------
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  # if (isTRUE(update_values) || isTRUE(update_NAs)) {
-  #   var_use <- sub(
-  #     pattern = "\\.y$",
-  #     replacement = "",
-  #     x = newyvars[
-  #       grepl(
-  #         pattern = "\\.y$",
-  #         x       = newyvars
-  #       )
-  #     ]
-  #   )
-  # }
   var_use <- NULL
   if (isTRUE(update_values) || isTRUE(update_NAs)) {
     var_use <- common_vars
@@ -462,6 +448,11 @@ joyn <- function(x,
                          .yreport = NULL)
 
 
+  if (sort) {
+    setorderv(x, by, na.last = na.last)
+    setattr(x, 'sorted', by)
+  }
+
   ## Rename by variables -----
 
   if (!is.null(fixby$xby)) {
@@ -519,10 +510,6 @@ joyn <- function(x,
     x |> fselect(get(reportvar)) <- NULL
   }
 
-  if (sort) {
-    setorderv(x, by, na.last = na.last)
-    setattr(x, 'sorted', by)
-  }
 
   if (verbose == TRUE) {
     end_joyn <- Sys.time()

--- a/tests/testthat/test-joyn.R
+++ b/tests/testthat/test-joyn.R
@@ -568,8 +568,8 @@ test_that("different names in key vars are working fine", {
                    ".joyn" = c("x & y", "x & y", "x", "y", "x", "x & y", "y", "y")
                    )
 
-  setorderv(dd, "id1", na.last = TRUE)
-  setattr(dd, 'sorted', "id1")
+  setorderv(dd, c("id1", "id2"), na.last = TRUE)
+  setattr(dd, 'sorted', c("id1", "id2"))
 
   expect_equal(df, dd)
 


### PR DESCRIPTION
This PR fixes two small bugs in the `joyn::joyn()`.

1. The input keys in input tables were being renamed to "keyby1" if the input tables did not have the same row names. [See this task](https://app.clickup.com/t/8687ehx5f). 
2. The order of returned data frames were not correct. See [this task](https://app.clickup.com/t/86879u7kk). 